### PR TITLE
Fix typo: 'snowmobie' -> 'snowmobile'

### DIFF
--- a/data/dictionary.tsv
+++ b/data/dictionary.tsv
@@ -87459,7 +87459,7 @@
 (NW)	odaabaanaakozidens+an	runner: skidoo ~
 (NW)	odaabaanaakozidens+an	runner: snowmobile ~
 (NW)	odaabaanaakozidens+an	skidoo runner
-(NW)	odaabaanaakozidens+an	snowmobie runner
+(NW)	odaabaanaakozidens+an	snowmobile runner
 	odaabaan+an	car [train]
 	odaabaan+an	trailer: truck ~
 (vti)(SE)	odaapanan	pick ST up


### PR DESCRIPTION
Typo in dictionary, it may be in the original Freelang dictionary as well.